### PR TITLE
grabBodyFromEmail(): allow grab email MIME-part with Content-part alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ Returns the string containing all of the recipients, such as To, CC and if provi
 grabBodyFromEmail
 ```
 Returns the email body as string
+```
+$email_body = $I->grabBodyFromEmail('text/html');
+$doc = new DOMDocument();
+$doc->loadHTML($email_body);
+$login = $doc->getElementById('login')->textContent;
+$password = $doc->getElementById('password')->textContent;
+```
+Fetch login & password from 'text/html' email MIME-part.
 
 ### To Do
 While this framework should be sufficient for most email testing scenarios, the remaining features need to be implemented
@@ -265,5 +273,5 @@ THE SOFTWARE.
    [MailHogModule]: http://github.com/ericmartel/codeception-email-mailhog
    [MailCatcherModule]: http://github.com/ericmartel/codeception-email-mailcatcher
    [MailtrapModule]: http://github.com/ericmartel/codeception-email-mailtrap
-   
+
 

--- a/src/TestsEmails.php
+++ b/src/TestsEmails.php
@@ -20,7 +20,7 @@ trait TestsEmails
 {
   /**
    * Have Emails
-   * 
+   *
    * Checks if there are any emails in the inbox
    */
   public function haveEmails()
@@ -31,7 +31,7 @@ trait TestsEmails
 
   /**
    * Have Number Of Emails
-   * 
+   *
    * Checks that the amount of emails in the inbox is exactly $expected
    * @params int $expected Number of expected emails
    */
@@ -43,7 +43,7 @@ trait TestsEmails
 
   /**
    * Dont Have Emails
-   * 
+   *
    * Checks that there are no emails in the inbox
    */
   public function dontHaveEmails()
@@ -54,7 +54,7 @@ trait TestsEmails
 
   /**
    * Have Unread Emails
-   * 
+   *
    * Checks that there is at least one unread email
    **/
   public function haveUnreadEmails()
@@ -65,7 +65,7 @@ trait TestsEmails
 
   /**
    * Have Number Of Unread Emails
-   * 
+   *
    * Checks that the amount of emails in the unread inbox is exactly $expected
    * @params int $expected Number of expected emails
    */
@@ -77,7 +77,7 @@ trait TestsEmails
 
   /**
    * Dont Have Unread Emails
-   * 
+   *
    * Checks that there are no unread emails in the inbox
    */
   public function dontHaveUnreadEmails()
@@ -88,9 +88,9 @@ trait TestsEmails
 
   /**
    * See In Opened Email Body
-   * 
+   *
    * Validates that $expected can be found in the opened email body
-   * 
+   *
    * @param string $expected Text
    */
   public function seeInOpenedEmailBody($expected)
@@ -101,9 +101,9 @@ trait TestsEmails
 
   /**
    * See In Opened Email Subject
-   * 
+   *
    * Validates that $expected can be found in the opened email subject
-   * 
+   *
    * @param string $expected Text
    */
   public function seeInOpenedEmailSubject($expected)
@@ -114,9 +114,9 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email Body
-   * 
+   *
    * Checks that $expected cannot be found in the opened email body
-   * 
+   *
    * @param string $expected Text
    */
   public function dontSeeInOpenedEmailBody($expected)
@@ -127,9 +127,9 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email Subject
-   * 
+   *
    * Checks that $expected cannot be found in the opened email subject
-   * 
+   *
    * @param string $expected Text
    */
   public function dontSeeInOpenedEmailSubject($expected)
@@ -140,9 +140,9 @@ trait TestsEmails
 
   /**
    * See In Email Body
-   * 
+   *
    * Checks that the body of $email contains $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -153,9 +153,9 @@ trait TestsEmails
 
   /**
    * Dont See In Email Body
-   * 
+   *
    * Checks that the body of $email does not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -166,9 +166,9 @@ trait TestsEmails
 
   /**
    * See In Email Subject
-   * 
+   *
    * Checks that the subject of $email contains $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -179,9 +179,9 @@ trait TestsEmails
 
   /**
    * Dont See In Email Subject
-   * 
+   *
    * Checks that the subject of $email does not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -192,9 +192,9 @@ trait TestsEmails
 
   /**
    * See In Opened Email Sender
-   * 
+   *
    * Checks if the sender of the opened email contains $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function seeInOpenedEmailSender($expected)
@@ -205,9 +205,9 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email Sender
-   * 
+   *
    * Checks if the sender of the opened email does not contain $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function dontSeeInOpenedEmailSender($expected)
@@ -218,9 +218,9 @@ trait TestsEmails
 
   /**
    * See In Email Sender
-   * 
+   *
    * Checks if the sender of $email contains $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -231,9 +231,9 @@ trait TestsEmails
 
   /**
    * Dont See In Email Sender
-   * 
+   *
    * Checks if the sender of $email does not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -244,9 +244,9 @@ trait TestsEmails
 
   /**
    * See In Opened Email Reply To
-   * 
+   *
    * Checks if the ReplyTo of the opened email contains $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function seeInOpenedEmailReplyTo($expected)
@@ -257,9 +257,9 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email Reply To
-   * 
+   *
    * Checks if the ReplyTo of the opened email does not contain $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function dontSeeInOpenedEmailReplyTo($expected)
@@ -270,9 +270,9 @@ trait TestsEmails
 
   /**
    * See In Email Reply To
-   * 
+   *
    * Checks if the ReplyTo of $email contains $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -283,9 +283,9 @@ trait TestsEmails
 
   /**
    * Dont See In Email Reply To
-   * 
+   *
    * Checks if the ReplyTo of $email does not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -296,9 +296,9 @@ trait TestsEmails
 
   /**
    * See In Opened Email Recipients
-   * 
+   *
    * Checks that the recipients of the opened email contain $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function seeInOpenedEmailRecipients($expected)
@@ -309,9 +309,9 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email Recipients
-   * 
+   *
    * Checks that the recipients of the opened email do not contain $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function dontSeeInOpenedEmailRecipients($expected)
@@ -322,9 +322,9 @@ trait TestsEmails
 
   /**
    * See In Email Recipients
-   * 
+   *
    * Checks that the recipients of $email contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -335,9 +335,9 @@ trait TestsEmails
 
   /**
    * Dont See In Email Recipients
-   * 
+   *
    * Checks that the recipients of $email do not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
    */
@@ -348,9 +348,9 @@ trait TestsEmails
 
   /**
    * See In Opened Email To Field
-   * 
+   *
    * Checks that the To field of the opened email contains $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function seeInOpenedEmailToField($expected)
@@ -361,9 +361,9 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email To Field
-   * 
+   *
    * Checks that the To field of the opened email does not contain $expected
-   * 
+   *
    * @param string $expected Text
    */
   public function dontSeeInOpenedEmailToField($expected)
@@ -374,12 +374,12 @@ trait TestsEmails
 
   /**
    * See In Email To Field
-   * 
+   *
    * Checks that the To field of $email contains $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
-   */  
+   */
   public function seeInEmailToField($email, $expected)
   {
     $this->assertContains($expected, $this->getEmailTo($email));
@@ -387,12 +387,12 @@ trait TestsEmails
 
   /**
    * Dont See In Email To Field
-   * 
+   *
    * Checks that the To field of $email does not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
-   */ 
+   */
   public function dontSeeInEmailToField($email, $expected)
   {
     $this->assertNotContains($expected, $this->getEmailTo($email));
@@ -400,11 +400,11 @@ trait TestsEmails
 
   /**
    * See In Opened Email CC Field
-   * 
+   *
    * Checks that the CC field of the opened email contains $expected
-   * 
+   *
    * @param string $expected Text
-   */  
+   */
   public function seeInOpenedEmailCCField($expected)
   {
     $email = $this->getOpenedEmail();
@@ -413,11 +413,11 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email CC Field
-   * 
+   *
    * Checks that the CC field of the opened email does not contain $expected
-   * 
+   *
    * @param string $expected Text
-   */ 
+   */
   public function dontSeeInOpenedEmailCCField($expected)
   {
     $email = $this->getOpenedEmail();
@@ -426,12 +426,12 @@ trait TestsEmails
 
   /**
    * See In Email CC Field
-   * 
+   *
    * Checks that the CC field of $email contains $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
-   */  
+   */
   public function seeInEmailCCField($email, $expected)
   {
     $this->assertContains($expected, $this->getEmailCC($email));
@@ -439,12 +439,12 @@ trait TestsEmails
 
   /**
    * Dont See In Email CC Field
-   * 
+   *
    * Checks that the CC field of $email does not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
-   */  
+   */
   public function dontSeeInEmailCCField($email, $expected)
   {
     $this->assertNotContains($expected, $this->getEmailCC($email));
@@ -452,13 +452,13 @@ trait TestsEmails
 
   /**
    * See In Opened Email BCC Field
-   * 
+   *
    * Checks that the BCC field of the opened email contains $expected
-   * 
+   *
    * Warning: it is possible for an email to have its BCC field empty, it doesn't mean that another instance of the same email doesn't exist.
-   * 
+   *
    * @param string $expected Text
-   */  
+   */
   public function seeInOpenedEmailBCCField($expected)
   {
     $email = $this->getOpenedEmail();
@@ -467,13 +467,13 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email BCC Field
-   * 
+   *
    * Checks that the BCC field of the opened email does not contain $expected
-   * 
+   *
    * Warning: it is possible for an email to have its BCC field empty, it doesn't mean that another instance of the same email doesn't exist.
-   * 
+   *
    * @param string $expected Text
-   */ 
+   */
   public function dontSeeInOpenedEmailBCCField($expected)
   {
     $email = $this->getOpenedEmail();
@@ -482,14 +482,14 @@ trait TestsEmails
 
   /**
    * See In Email BCC Field
-   * 
+   *
    * Checks that the BCC field of $email contains $expected
-   * 
+   *
    * Warning: it is possible for an email to have its BCC field empty, it doesn't mean that another instance of the same email doesn't exist.
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
-   */  
+   */
   public function seeInEmailBCCField($email, $expected)
   {
     $this->assertContains($expected, $this->getEmailBCC($email));
@@ -497,14 +497,14 @@ trait TestsEmails
 
   /**
    * Dont See In Email BCC Field
-   * 
+   *
    * Checks that the BCC field of $email does not contain $expected
-   * 
+   *
    * Warning: it is possible for an email to have its BCC field empty, it doesn't mean that another instance of the same email doesn't exist.
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected Text
-   */ 
+   */
   public function dontSeeInEmailBCCField($email, $expected)
   {
     $this->assertNotContains($expected, $this->getEmailBCC($email));
@@ -512,9 +512,9 @@ trait TestsEmails
 
   /**
    * See In Opened Email Priority
-   * 
+   *
    * Checks that the priority of the opened email contains $expected
-   * 
+   *
    * @param string $expected priority
    */
   public function seeInOpenedEmailPriority($expected)
@@ -525,9 +525,9 @@ trait TestsEmails
 
   /**
    * Dont See In Opened Email Priority
-   * 
+   *
    * Checks that the priority of the opened email does not contain $expected
-   * 
+   *
    * @param string $expected priority
    */
   public function dontSeeInOpenedEmailPriority($expected)
@@ -538,12 +538,12 @@ trait TestsEmails
 
   /**
    * See In Email Priority
-   * 
+   *
    * Checks that the priority of $email contains $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected priority
-   */ 
+   */
   public function seeInEmailPriority($email, $expected)
   {
     $this->assertContains($expected, $this->getEmailPriority($email));
@@ -551,9 +551,9 @@ trait TestsEmails
 
   /**
    * Dont See In Email Priority
-   * 
+   *
    * Checks that the priority of $email does not contain $expected
-   * 
+   *
    * @param mixed $email a JSON encoded email
    * @param string $expected priority
    */
@@ -563,11 +563,23 @@ trait TestsEmails
   }
 
     /**
+
+     * @param string $content_type_alternative      MIME-part Content-Type
      * @return string Body
      */
-    public function grabBodyFromEmail()
+    public function grabBodyFromEmail($content_type_alternative = null)
     {
         $email = $this->getOpenedEmail();
-        return $this->getDecodedEmailProperty($email, $email->Content->Body);
+
+        if( isset($content_type_alternative) ) {
+            foreach ($email->MIME->Parts as $part) {
+                if (!empty($part->Headers->{'Content-Type'}[0]) &&
+                    strpos($part->Headers->{'Content-Type'}[0], $content_type_alternative) !== false) {
+                    return $this->getDecodedEmailProperty($part, $part->Body);  //return first entry
+                }
+            }
+            return null;                                                        //not found
+        }
+        return $this->getDecodedEmailProperty($email, $email->Content->Body);   //return full email
     }
 };


### PR DESCRIPTION
Hello Eric,

Often email message is multi-part and you need to grab only one alternative. 
I've updated the method grabBodyFromEmail() to deal both cases.
See usage example in README.md

Merry Christmas,
Yuri